### PR TITLE
-property is dead

### DIFF
--- a/docs/source/distutils.rst
+++ b/docs/source/distutils.rst
@@ -115,7 +115,7 @@ d_property
 Have D compilers enable property checks (i.e. trying to call functions without 
 parens will result in an error)
 
-Default: :code:`True`
+Default: :code:`False`
 
 string_imports
 --------------

--- a/support.py
+++ b/support.py
@@ -43,7 +43,7 @@ class Extension(std_Extension):
         self.with_main = kwargs.pop('with_main', True)
         self.pyd_optimize = kwargs.pop('optimize', False)
         self.d_unittest = kwargs.pop('d_unittest', False)
-        self.d_property = kwargs.pop('d_property', True)
+        self.d_property = kwargs.pop('d_property', False)
         self.d_lump = kwargs.pop('d_lump', False)
         self.string_imports = kwargs.pop('string_imports', [])
         if self.with_main and not self.with_pyd:


### PR DESCRIPTION
I'm sure there are people out there who use it, but it really shouldn't be the default. Calling functions without parenthesis is now common in released D code.