### PR TITLE
add python3.5 and remove wrong OS X paths

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -50,8 +50,7 @@
             "libs-posix": ["python3.3m"],
             "libs-windows-dmd": [
                 "$PYD_PACKAGE_DIR\\infrastructure\\windows\\python33_digitalmars"
-            ],
-            "lflags-osx": ["-L/Library/Frameworks/Python.framework/Versions/3.3/lib/"]
+            ]
         },
         {
             "name": "python34",
@@ -69,8 +68,26 @@
             "libs-posix": ["python3.4m"],
             "libs-windows-dmd": [
                 "$PYD_PACKAGE_DIR\\infrastructure\\windows\\python34_digitalmars"
+            ]
+        },
+        {
+            "name": "python35",
+            "versions": [
+                "Python_2_4_Or_Later",
+                "Python_2_5_Or_Later",
+                "Python_2_6_Or_Later",
+                "Python_2_7_Or_Later",
+                "Python_3_0_Or_Later",
+                "Python_3_1_Or_Later",
+                "Python_3_2_Or_Later",
+                "Python_3_3_Or_Later",
+                "Python_3_4_Or_Later",
+                "Python_3_5_Or_Later"
             ],
-            "lflags-osx": ["-L/Library/Frameworks/Python.framework/Versions/3.4/lib/"]
+            "libs-posix": ["python3.5m"],
+            "libs-windows-dmd": [
+                "$PYD_PACKAGE_DIR\\infrastructure\\windows\\python35_digitalmars"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Those OS X paths are really not reliable. They've moved around across OS X versions and also many people use python installed in other directories (macports and homebrew).