### PR TITLE
s/pointerTarget/PointerTarget/g due to pointerTarget being gone from phobos

### DIFF
--- a/infrastructure/pyd/ctor_wrap.d
+++ b/infrastructure/pyd/ctor_wrap.d
@@ -71,7 +71,7 @@ template wrapped_struct_init(T) if (is(T == struct)){
 // This template accepts a tuple of function pointer types, which each describe
 // a ctor of T, and  uses them to wrap a Python tp_init function.
 template wrapped_ctors(string classname, T,Shim, C ...) 
-if(is(T == class) || (isPointer!T && is(pointerTarget!T == struct))) {
+if(is(T == class) || (isPointer!T && is(PointerTarget!T == struct))) {
     //alias shim_class T;
     alias wrapped_class_object!(T) wrap_object;
     alias NewParamT!T U;

--- a/infrastructure/pyd/func_wrap.d
+++ b/infrastructure/pyd/func_wrap.d
@@ -714,12 +714,12 @@ template isSharedFunction(T...) if (T.length == 1) {
 }
 
 template funcTarget(T...) if(T.length == 1) {
-    static if(isPointer!(T[0]) && is(pointerTarget!(T[0]) == function)) {
-        alias pointerTarget!(T[0]) funcTarget;
+    static if(isPointer!(T[0]) && is(PointerTarget!(T[0]) == function)) {
+        alias PointerTarget!(T[0]) funcTarget;
     }else static if(is(T[0] == function)) {
         alias T[0] funcTarget;
     }else static if(is(T[0] == delegate)) {
-        alias pointerTarget!(typeof((T[0]).init.funcptr)) funcTarget;
+        alias PointerTarget!(typeof((T[0]).init.funcptr)) funcTarget;
     }else static assert(false);
 }
 

--- a/infrastructure/pyd/make_object.d
+++ b/infrastructure/pyd/make_object.d
@@ -575,7 +575,7 @@ T python_to_d(T) (PyObject* o) {
             return t;
         }
         return python_to_d_try_extends!T(o);
-    } else static if (isPointer!T && is(pointerTarget!T == struct)) { 
+    } else static if (isPointer!T && is(PointerTarget!T == struct)) { 
         // pointer to struct   
         if (is_wrapped!(T) && PyObject_TypeCheck(o, &PydTypeObject!(T))) {
             return get_d_reference!(T)(o);
@@ -601,7 +601,7 @@ T python_to_d(T) (PyObject* o) {
         return python_to_d_string!T(o);
     } else static if (isArray!T || IsStaticArrayPointer!T) {
         static if(isPointer!T) {
-            alias Unqual!(ElementType!(pointerTarget!T)) E;
+            alias Unqual!(ElementType!(PointerTarget!T)) E;
         }else {
             alias Unqual!(ElementType!T) E;
         }
@@ -801,7 +801,7 @@ T python_to_d_string(T) (PyObject* o) {
 T python_array_array_to_d(T)(PyObject* o) 
 if(isArray!T || IsStaticArrayPointer!T) {
     static if(isPointer!T)
-        alias Unqual!(ElementType!(pointerTarget!T)) E;
+        alias Unqual!(ElementType!(PointerTarget!T)) E;
     else
         alias Unqual!(ElementType!T) E;
     if(o.ob_type !is array_array_Type)
@@ -887,7 +887,7 @@ PyObject* d_to_python_bytes(T)(T t) if(is(T == string)) {
   */
 T python_iter_to_d(T)(PyObject* o) if(isArray!T || IsStaticArrayPointer!T) {
     static if(isPointer!T)
-        alias Unqual!(ElementType!(pointerTarget!T)) E;
+        alias Unqual!(ElementType!(PointerTarget!T)) E;
     else
         alias Unqual!(ElementType!T) E;
     PyObject* iter = PyObject_GetIter(o);
@@ -911,7 +911,7 @@ T python_iter_to_d(T)(PyObject* o) if(isArray!T || IsStaticArrayPointer!T) {
                     format("length mismatch: %s vs %s", 
                         len, T.length));
     }else static if(isPointer!T){
-        ubyte[] bufi = new ubyte[](pointerTarget!T.sizeof);
+        ubyte[] bufi = new ubyte[](PointerTarget!T.sizeof);
         _array = cast(MatrixInfo!T.unqual)(bufi.ptr);
     }
     int i = 0;
@@ -1299,7 +1299,7 @@ template IsStaticArrayPointer(T) {
         }
     }
     static if(isPointer!T) {
-        enum bool IsStaticArrayPointer = _Inner!(pointerTarget!T);
+        enum bool IsStaticArrayPointer = _Inner!(PointerTarget!T);
     }else{
         enum bool IsStaticArrayPointer = false;
     }
@@ -1437,8 +1437,8 @@ post_code = code to mix in to each for loop after finishing the nested for loop.
         return s_begin ~ s_end;
     }
 
-    static if(isPointer!T && isStaticArray!(pointerTarget!T)) {
-        alias _dim_list!(pointerTarget!T) _dim;
+    static if(isPointer!T && isStaticArray!(PointerTarget!T)) {
+        alias _dim_list!(PointerTarget!T) _dim;
         /// T, with all nonmutable qualifiers stripped away.
         alias _dim.unqual* unqual;
     }else{

--- a/infrastructure/pyd/references.d
+++ b/infrastructure/pyd/references.d
@@ -158,19 +158,19 @@ struct DStruct_Py_Mapping {
     Constness constness;
 
     this(S)(S d, PyObject* py) if(isPointer!S &&
-            is(pointerTarget!S == struct)) {
+            is(PointerTarget!S == struct)) {
         this.d = DKey(d);
         this.d_typeinfo = typeid(TypeInfoType!S);
         this.py = py;
         this.constness = .constness!S;
     }
 
-    template TypeInfoType(T) if(isPointer!T && is(pointerTarget!T == struct)) {
+    template TypeInfoType(T) if(isPointer!T && is(PointerTarget!T == struct)) {
         alias Unqual!T TypeInfoType;
     }
 
     public static const(void)* DKey(T)(T t)
-        if(isPointer!T && is(pointerTarget!T == struct)) {
+        if(isPointer!T && is(PointerTarget!T == struct)) {
             return cast(const(void)*) t;
     }
 
@@ -245,7 +245,7 @@ template pyd_references(T) {
         alias DDg_Py_Mapping Mapping;
     }else static if (isFunctionPointer!T) {
         alias DFn_Py_Mapping Mapping;
-    }else static if(isPointer!T && is(pointerTarget!T == struct)) {
+    }else static if(isPointer!T && is(PointerTarget!T == struct)) {
         alias DStruct_Py_Mapping Mapping;
     }else static if (is(T == class)) {
         alias DClass_Py_Mapping Mapping;

--- a/infrastructure/util/typeinfo.d
+++ b/infrastructure/util/typeinfo.d
@@ -122,8 +122,8 @@ template StripSafeTrusted(F) {
     enum linkage = functionLinkage!F;
     alias SetFunctionAttributes!(F, linkage, desired_attrs) unqual_F;
     static if(isFunctionPointer!F) {
-        enum constn = constness!(pointerTarget!F);
-        alias ApplyConstness!(pointerTarget!unqual_F, constn)* StripSafeTrusted;
+        enum constn = constness!(PointerTarget!F);
+        alias ApplyConstness!(PointerTarget!unqual_F, constn)* StripSafeTrusted;
     }else static if(isDelegate!F) {
         enum constn = constness!(F);
         alias ApplyConstness!(unqual_F, constn) StripSafeTrusted;


### PR DESCRIPTION
it was deprecated, but now it's gone. Lead to completely misleading errors with the latest dmd beta, but this is the fix.