### PR TITLE
Now works when Python path on Windows has spaces (Issue 52)

### DIFF
--- a/dcompiler.py
+++ b/dcompiler.py
@@ -919,11 +919,12 @@ def _findInPath(fileName, startIn=None):
     return None
 
 
-def _qp(path): # If path contains any whitespace, quote it.
-    if len(path.split()) == 1:
-        return path
-    else:
-        return '"%s"' % path
+def _qp(path): # Originally: If path contains any whitespace, quote it.
+    # Actually paths with spaces will be quoted again later
+    # so if we do it here, there will be extra quotes like
+    # ""C:\Program Files\..."" and the build will fail
+    # So, don't do it here.
+    return path
 
 def _is_win64():
     import platform


### PR DESCRIPTION
I tried to build examples/hello on Windows and immediately bumped into a problem with Python being installed in Program Files. The paths were quoted twice, so dmd was being invoked with arguments like
""c:\Program Files\...\smth.d"" 
and of course it complained about not knowing module Program (first word in Program Files).
Turns out if we don't try to quote the paths in dcompiler.py, then they are quoted later just once and everything starts to work fine, at least the example built and worked successfully.