### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ their own verisoning schemes, I only pay attention to the front end version.
 [build-status]: https://travis-ci.org/ariovistus/pyd
 [docs-badge]: https://readthedocs.org/projects/pyd/badge/
 [docs]: http://pyd.readthedocs.org/
-[pypi-version]: https://pypip.in/version/pyd/badge.svg
+[pypi-version]: https://img.shields.io/pypi/v/pyd.svg
 [pypi]: https://pypi.python.org/pypi/pyd
-[license-badge]: https://pypip.in/license/pyd/badge.svg
+[license-badge]: https://img.shields.io/pypi/l/pyd.svg
 [license]: https://pypi.python.org/pypi/pyd/


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pyd))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pyd`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.