### PR TITLE
Python37

### DIFF
--- a/infrastructure/deimos/python/datetime.d
+++ b/infrastructure/deimos/python/datetime.d
@@ -214,17 +214,22 @@ struct PyDateTime_CAPI {
     /// ditto
     PyTypeObject* TZInfoType;
 
+    version(Python_3_7_Or_Later)
+        PyObject* TimeZone_UTC;
+
     /** constructors */
     PyObject* function(int, int, int, PyTypeObject*) Date_FromDate;
     /// ditto
     PyObject* function(int, int, int, int, int, int, int,
-            PyObject*, PyTypeObject*) 
+            PyObject*, PyTypeObject*)
         DateTime_FromDateAndTime;
     /// ditto
-    PyObject* function(int, int, int, int, PyObject*, PyTypeObject*) 
+    PyObject* function(int, int, int, int, PyObject*, PyTypeObject*)
         Time_FromTime;
     /// ditto
     PyObject* function(int, int, int, int, PyTypeObject*) Delta_FromDelta;
+    /// ditto
+    version(Python_3_7_Or_Later) PyObject* function(PyObject *offset, PyObject *name) TimeZone_FromTimeZone;
 
     /** constructors for the DB API */
     PyObject* function(PyObject*, PyObject*, PyObject*) DateTime_FromTimestamp;
@@ -232,10 +237,10 @@ struct PyDateTime_CAPI {
     PyObject* function(PyObject*, PyObject*) Date_FromTimestamp;
 
     version(Python_3_6_Or_Later) {
-        PyObject* function(int, int, int, int, int, int, int, PyObject*, int, PyTypeObject*) 
+        PyObject* function(int, int, int, int, int, int, int, PyObject*, int, PyTypeObject*)
             DateTime_FromDateAndTimeAndFold;
 
-        PyObject* function(int, int, int, int, PyObject*, int, PyTypeObject*) 
+        PyObject* function(int, int, int, int, PyObject*, int, PyTypeObject*)
             Time_FromTimeAndFold;
     }
 }
@@ -312,18 +317,18 @@ PyObject* PyDate_FromDate()(int year, int month, int day) {
 PyObject* PyDateTime_FromDateAndTime()(
         int year, int month, int day, int hour, int min, int sec, int usec) {
     return PyDateTimeAPI.DateTime_FromDateAndTime(
-            year, month, day, hour, min, sec, usec, 
+            year, month, day, hour, min, sec, usec,
             cast(PyObject*) Py_None(), PyDateTimeAPI.DateTimeType);
 }
 
 version(Python_3_6_Or_Later) {
     /// _
     PyObject* PyDateTime_FromDateAndTimeAndFold()(
-            int year, int month, int day, int hour, int min, int sec, 
+            int year, int month, int day, int hour, int min, int sec,
             int usec, int fold) {
         return PyDateTimeAPI.DateTime_FromDateAndTimeAndFold(
                 year, month, day, hour,
-                min, sec, usec, cast(PyObject*) Py_None(), fold, 
+                min, sec, usec, cast(PyObject*) Py_None(), fold,
                 PyDateTimeAPI.DateTimeType);
     }
 }
@@ -357,5 +362,3 @@ PyObject* PyDate_FromTimestamp()(PyObject* args) {
     return PyDateTimeAPI.Date_FromTimestamp(
             cast(PyObject*) (PyDateTimeAPI.DateType), args);
 }
-
-

--- a/infrastructure/deimos/python/pystate.d
+++ b/infrastructure/deimos/python/pystate.d
@@ -236,7 +236,16 @@ PyObject_BorrowedRef* PyThreadState_GetDict();
 /// _
 int PyThreadState_SetAsyncExc(C_long, PyObject*);
 
-version(Python_3_0_Or_Later) {
+version(Python_3_7_Or_Later) {
+    ///
+    mixin(PyAPI_DATA!"PyThreadState* _PyThreadState_UncheckedGet");
+
+    ///
+    auto PyThreadState_GET()() {
+        return _PyThreadState_UncheckedGet;
+    }
+
+} else version(Python_3_0_Or_Later) {
     /// _
     mixin(PyAPI_DATA!"_Py_atomic_address _PyThreadState_Current");
 
@@ -245,7 +254,7 @@ version(Python_3_0_Or_Later) {
         return cast(PyThreadState*)
                 _Py_atomic_load_relaxed(&_PyThreadState_Current);
     }
-}else{
+} else {
     /// _
     mixin(PyAPI_DATA!"PyThreadState* _PyThreadState_Current");
 


### PR DESCRIPTION
Sorry for the multiple PRs. I thought the upgrade to Python 3.7 would be trivial but I was mistaken. Now that I finally tried testing autowrap with Python 3.7 I had to fix two issues:

- As seen in the [Python 3.7 changelog](https://docs.python.org/3/whatsnew/changelog.html), `_PyThreadState_Current` is no longer available and trying to link to it fails.
- The layout of `PyDateTime_CAPI` changed, leading to crashes.

With this PR, autowrap works correctly with Python 3.7 and all tests pass, including the ones involving dates and date times.