### PR TITLE
add env configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -211,6 +211,7 @@ install:
 script: 
     - python3 runtests.py --compiler=$DC $TEST
     - dub test
+    - source set_env_vars.sh python3 && dub test -c env
 
 jobs:
     include:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@
 
 PyD provides seamless interoperability between Python and the D programming language.
 
+# Usage
+
+To use with dub, either specify the relevant subConfiguration, or run
+`source set_env_vars.sh <your python>` on linux or
+`set_env_vars.bat <your python>` on windows to set the relevant environment variables
+and use the `env` subConfiguration
+
 # Requirements
 
 ## Python

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,3 +81,6 @@ build_script:
 test_script:
     - ps: . "$env:MYPYTHONPATH\python.exe" runtests.py --compiler=$env:DC "$env:TEST"
     - ps: echo "$? $lastExitCode"
+    - cmd: dub test
+    - cmd: set_env_vars.bat
+    - cmd: dub test -c env

--- a/dub.json
+++ b/dub.json
@@ -206,6 +206,33 @@
 				"Python_3_6_Or_Later",
 				"Python_3_7_Or_Later"
 			]
+		},
+		{
+			"name": "env",
+			"versions": [
+				"$PYD_D_VERSION_1",
+				"$PYD_D_VERSION_2",
+				"$PYD_D_VERSION_3",
+				"$PYD_D_VERSION_4",
+				"$PYD_D_VERSION_5",
+				"$PYD_D_VERSION_6",
+				"$PYD_D_VERSION_7",
+				"$PYD_D_VERSION_8",
+				"$PYD_D_VERSION_9",
+				"$PYD_D_VERSION_10",
+				"$PYD_D_VERSION_11",
+				"$PYD_D_VERSION_12",
+				"$PYD_D_VERSION_13",
+			],
+			"lflags-posix": [
+				"-L$PYD_LIBPYTHON_DIR"
+			],
+			"lflags-windows": [
+				"/LIBPATH:$PYD_LIBPYTHON_DIR"
+			],
+			"libs": [
+				"$PYD_LIBPYTHON"
+			]
 		}
 	],
 	"importPaths": [

--- a/get_env_set_text.py
+++ b/get_env_set_text.py
@@ -1,0 +1,36 @@
+from distutils import sysconfig
+import os
+
+python_version = sysconfig.get_config_var('VERSION')
+python_version_compact = python_version.replace('.', '')
+
+if python_version_compact[0] == '2':
+	versionNumbers = list(map(lambda n: '2_' + str(n),
+		range(4, int(python_version_compact[1]) + 1)))
+else:
+	versionNumbers = list(map(lambda n: '2_' + str(n),
+		range(4, 8)))
+	versionNumbers += list(map(lambda n: '3_' + str(n),
+		range(0, int(python_version_compact[1]) + 1)))
+
+if os.name == 'nt':
+	set_prefix = 'set'
+else:
+    set_prefix = 'export'
+
+for i in range(13):
+	if i < len(versionNumbers):
+		v = "Python_{}_Or_Later".format(versionNumbers[i])
+	else:
+		v = "__PYD__DUMMY__"
+	print("{} PYD_D_VERSION_{}={}".format(set_prefix, i + 1, v))
+
+if os.name == 'nt':
+	library_path = os.path.join(sysconfig.get_config_var('BINDIR'), "libs")
+	libname = "python" + python_version_compact
+else:
+	library_path = sysconfig.get_config_var('LIBDIR')
+	libname = "python" + python_version + 'm'
+
+print("{} PYD_LIBPYTHON_DIR={}".format(set_prefix, library_path))
+print("{} PYD_LIBPYTHON={}".format(set_prefix, libname))

--- a/set_env_vars.bat
+++ b/set_env_vars.bat
@@ -1,0 +1,16 @@
+@echo off
+
+if "%1"=="" (
+	echo python interpreter not specified, using ""python""
+	set PYD_PYTHON=python
+) else (
+	set PYD_PYTHON=%1
+)
+
+%PYD_PYTHON% %~dp0\get_env_set_text.py > tmp_pyd_env_set.bat
+if %errorlevel% neq 0 exit /b %errorlevel%
+call tmp_pyd_env_set.bat
+set result=%errorlevel%
+del tmp_pyd_env_set.bat
+if %errorlevel% neq 0 exit /b %errorlevel%
+exit /b %result%

--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -15,4 +15,4 @@ else
 	PYD_PYTHON=$1
 fi
 
-eval $($PYTHON $THISDIR/get_env_set_text.py)
+eval $($PYD_PYTHON $THISDIR/get_env_set_text.py)

--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -1,0 +1,18 @@
+if [ -v BASH_SOURCE ]; then
+	THIS=${BASH_SOURCE[0]}
+elif [ -v ZSH_VERSION ]; then
+	THIS=${(%):-%x}
+else
+	THIS=$0
+fi
+
+THISDIR=$( cd $(dirname $THIS) > /dev/null ; pwd -P )
+
+if [ -z $1 ]; then
+	echo 'python interpreter not specified, using "python"'
+	PYD_PYTHON=python
+else
+	PYD_PYTHON=$1
+fi
+
+eval $($PYTHON $THISDIR/get_env_set_text.py)


### PR DESCRIPTION
This enables people to control which version of pyd they are using in order to appropriately match the system without specifying endless configurations that reference subConfigurations that reference subConfigurations and so on...

This will make using pyd in larger dub package hierarchies significantly easier.