### PR TITLE
no more sourceLibrary

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,7 +5,6 @@
 	"configurations": [
 		{
 			"name": "python27",
-			"targetType": "sourceLibrary",
 			"libs-windows-x86-dmd": [
 				"$PYD_PACKAGE_DIR\\infrastructure\\windows\\python27_digitalmars"
 			],
@@ -33,7 +32,6 @@
 		},
 		{
 			"name": "python33",
-			"targetType": "sourceLibrary",
 			"libs-windows-x86-dmd": [
 				"$PYD_PACKAGE_DIR\\infrastructure\\windows\\python33_digitalmars"
 			],
@@ -65,7 +63,6 @@
 		},
 		{
 			"name": "python34",
-			"targetType": "sourceLibrary",
 			"libs-windows-x86-dmd": [
 				"$PYD_PACKAGE_DIR\\infrastructure\\windows\\python34_digitalmars"
 			],
@@ -98,7 +95,6 @@
 		},
 		{
 			"name": "python35",
-			"targetType": "sourceLibrary",
 			"libs-windows-x86-dmd": [
 				"$PYD_PACKAGE_DIR\\infrastructure\\windows\\python35_digitalmars"
 			],
@@ -132,7 +128,6 @@
 		},
 		{
 			"name": "python36",
-			"targetType": "sourceLibrary",
 			"libs-windows-x86-dmd": [
 				"$PYD_PACKAGE_DIR\\infrastructure\\windows\\python36_digitalmars"
 			],
@@ -170,7 +165,6 @@
 		},
 		{
 			"name": "python37",
-			"targetType": "sourceLibrary",
 			"libs-windows-x86-dmd": [
 				"$PYD_PACKAGE_DIR\\infrastructure\\windows\\python37_digitalmars"
 			],
@@ -215,7 +209,7 @@
 	"versions-osx": [
 		"Python_Unicode_UCS2"
 	],
-	"targetType": "sourceLibrary",
+	"targetType": "library",
 	"license": "MIT",
 	"version": "~master",
 	"versions-linux": [


### PR DESCRIPTION
It was needed because `dub` didn't apply `-fPIC` properly, but it has done for a decent long while now.