### PR TITLE
Dockertests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: minimal
 sudo: required
 services: 
 - docker
@@ -32,6 +33,18 @@ env:
   DUBCFG=python34
   RUNSPEC=runtests
   DOCKER=ariovistus/pyd-test-env:jessie-dmd2_074-py34
+- DC=gdc
+  PYTHON=python
+  DUBCFG=python37
+  RUNSPEC=runtests
+  DOCKER=ariovistus/pyd-test-env:stretch-gdc63-py37
+matrix: 
+  allow_failures:
+   - env: DC=gdc
+          PYTHON=python
+          DUBCFG=python37
+          RUNSPEC=runtests
+          DOCKER=ariovistus/pyd-test-env:stretch-gdc63-py37
 script: 
 - docker run -v$(pwd)/:/src -e "COMPILER=$DC" -e "RUNSPEC=$RUNSPEC" -e "PYTHON=$PYTHON" -e "DUBCONFIG=$DUBCFG" -t $DOCKER bash runtests.sh
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,233 +1,39 @@
-sudo: false
-
-os:
- - linux
- - osx
-
-language: d
-
-d:
- - dmd-2.073.0
- - dmd-2.072.2
- - dmd-2.071.2
- - dmd-2.070.2
- - dmd-2.069.2
- - dmd-2.068.2
- - dmd-2.067.1
- - ldc-1.1.0
- - ldc-1.0.0
-   # - ldc-0.17.3 # wtf, travis?
- - ldc-0.16.1
-   #- gdc-6.3.0 # wtf, travis?
-
-matrix:
-  allow_failures:
-   - d: ldc-0.15.1
-     env: TEST=runtests:test_extra
-   - d: ldc-0.16.1
-     env: TEST=runtests:test_extra
-   - d: ldc-1.0.0
-     env: TEST=runtests:test_extra
-   - d: ldc-1.1.0
-     env: TEST=runtests:test_extra
-
-  exclude:
-   - d: dmd-2.067.1
-     env: TEST=runtests:test_hello
-   - d: dmd-2.067.1
-     env: TEST=runtests:test_many_libs
-   - d: dmd-2.067.1
-     env: TEST=runtests:test_arraytest
-   - d: dmd-2.067.1
-     env: TEST=runtests:test_inherit
-   - d: dmd-2.067.1
-     env: TEST=runtests:test_rawexample
-   - d: dmd-2.067.1
-     env: TEST=runtests:test_testdll
-   - d: dmd-2.067.1
-     env: TEST=runtests:test_multithreading
-   - d: dmd-2.067.1
-     env: TEST=runtests:test_def
-   - d: dmd-2.067.1
-     env: TEST=runtests:test_d_and_c
-   - d: dmd-2.067.1
-     env:  TEST=runtests:test_compare_offsets
-
-   - d: ldc-1.1.0 
-     env: TEST=runtests:test_hello
-   - d: ldc-1.1.0 
-     env: TEST=runtests:test_many_libs
-   - d: ldc-1.1.0 
-     env: TEST=runtests:test_arraytest
-   - d: ldc-1.1.0 
-     env: TEST=runtests:test_inherit
-   - d: ldc-1.1.0 
-     env: TEST=runtests:test_rawexample
-   - d: ldc-1.1.0 
-     env: TEST=runtests:test_testdll
-   - d: ldc-1.1.0 
-     env: TEST=runtests:test_multithreading
-   - d: ldc-1.1.0 
-     env: TEST=runtests:test_def
-   - d: ldc-1.1.0 
-     env: TEST=runtests:test_d_and_c
-   - d: ldc-1.1.0 
-     env:  TEST=runtests:test_compare_offsets
-
-   - d: ldc-1.0.0 
-     env: TEST=runtests:test_hello
-   - d: ldc-1.0.0 
-     env: TEST=runtests:test_many_libs
-   - d: ldc-1.0.0 
-     env: TEST=runtests:test_arraytest
-   - d: ldc-1.0.0 
-     env: TEST=runtests:test_inherit
-   - d: ldc-1.0.0 
-     env: TEST=runtests:test_rawexample
-   - d: ldc-1.0.0 
-     env: TEST=runtests:test_testdll
-   - d: ldc-1.0.0 
-     env: TEST=runtests:test_multithreading
-   - d: ldc-1.0.0 
-     env: TEST=runtests:test_def
-   - d: ldc-1.0.0 
-     env: TEST=runtests:test_d_and_c
-   - d: ldc-1.0.0 
-     env:  TEST=runtests:test_compare_offsets
-
-   - d: ldc-0.16.1
-     env: TEST=runtests:test_hello
-   - d: ldc-0.16.1
-     env: TEST=runtests:test_many_libs
-   - d: ldc-0.16.1
-     env: TEST=runtests:test_arraytest
-   - d: ldc-0.16.1
-     env: TEST=runtests:test_inherit
-   - d: ldc-0.16.1
-     env: TEST=runtests:test_rawexample
-   - d: ldc-0.16.1
-     env: TEST=runtests:test_testdll
-   - d: ldc-0.16.1
-     env: TEST=runtests:test_multithreading
-   - d: ldc-0.16.1
-     env: TEST=runtests:test_def
-   - d: ldc-0.16.1
-     env: TEST=runtests:test_d_and_c
-   - d: ldc-0.16.1
-     env:  TEST=runtests:test_compare_offsets
-
-   - d: ldc-0.15.1
-     env: TEST=runtests:test_hello
-   - d: ldc-0.15.1
-     env: TEST=runtests:test_many_libs
-   - d: ldc-0.15.1
-     env: TEST=runtests:test_arraytest
-   - d: ldc-0.15.1
-     env: TEST=runtests:test_inherit
-   - d: ldc-0.15.1
-     env: TEST=runtests:test_rawexample
-   - d: ldc-0.15.1
-     env: TEST=runtests:test_testdll
-   - d: ldc-0.15.1
-     env: TEST=runtests:test_multithreading
-   - d: ldc-0.15.1
-     env: TEST=runtests:test_def
-   - d: ldc-0.15.1
-     env: TEST=runtests:test_d_and_c
-   - d: ldc-0.15.1
-     env:  TEST=runtests:test_compare_offsets
-
-   - d: gdc-4.9.2
-     env: TEST=runtests:test_hello
-   - d: gdc-4.9.2
-     env: TEST=runtests:test_many_libs
-   - d: gdc-4.9.2
-     env: TEST=runtests:test_arraytest
-   - d: gdc-4.9.2
-     env: TEST=runtests:test_inherit
-   - d: gdc-4.9.2
-     env: TEST=runtests:test_rawexample
-   - d: gdc-4.9.2
-     env: TEST=runtests:test_testdll
-   - d: gdc-4.9.2
-     env: TEST=runtests:test_multithreading
-   - d: gdc-4.9.2
-     env: TEST=runtests:test_def
-   - d: gdc-4.9.2
-     env: TEST=runtests:test_d_and_c
-   - d: gdc-4.9.2
-     env:  TEST=runtests:test_compare_offsets
-
-   - d: gdc-5.2.0
-     env: TEST=runtests:test_hello
-   - d: gdc-5.2.0
-     env: TEST=runtests:test_many_libs
-   - d: gdc-5.2.0
-     env: TEST=runtests:test_arraytest
-   - d: gdc-5.2.0
-     env: TEST=runtests:test_inherit
-   - d: gdc-5.2.0
-     env: TEST=runtests:test_rawexample
-   - d: gdc-5.2.0
-     env: TEST=runtests:test_testdll
-   - d: gdc-5.2.0
-     env: TEST=runtests:test_multithreading
-   - d: gdc-5.2.0
-     env: TEST=runtests:test_def
-   - d: gdc-5.2.0
-     env: TEST=runtests:test_d_and_c
-   - d: gdc-5.2.0
-     env:  TEST=runtests:test_compare_offsets
-  
-   - d: gdc-4.9.2
-   - d: gdc-5.2.0
-   #- os: osx
-   #  d: gdc-4.9.2
-   #- os: osx
-   #  d: gdc-5.2.0
-   - os: osx
-  env:
-   - ARCH=x86
-   - ARCH=x86_64
-
-addons:
-  apt:
-    packages:
-     - python3
-     - python
-     - python3-nose
-     - python-nose
-     - python3-numpy
-     - python-numpy
-     - python-dev
-     - python3-dev
+sudo: required
+services: 
+- docker
 env:
-    - TEST=runtests:test_hello
-    - TEST=runtests:test_many_libs
-    - TEST=runtests:test_arraytest
-    - TEST=runtests:test_inherit
-    - TEST=runtests:test_rawexample
-    - TEST=runtests:test_testdll
-    - TEST=runtests:test_d_and_c
-    - TEST=runtests:test_multithreading
-    - TEST=runtests:PydUnittests
-    - TEST=runtests:test_extra
-    - TEST=runtests:DeimosUnittests
-    - TEST=runtests:test_pyind
-    - TEST=runtests:test_simple_embedded
-    - TEST=runtests:test_interpcontext
-    - TEST=runtests:test_def
-    - TEST=runtests:test_pydobject
-    - TEST=runtests:test_compare_offsets
-
-install:
-    - python3 setup.py install --user
-
+- DC=dmd
+  PYTHON=python
+  DUBCFG=python37
+  RUNSPEC=runtests
+  DOCKER=ariovistus/pyd-test-env:stretch-dmd2_080-py37
+- DC=ldc
+  PYTHON=python3
+  DUBCFG=python35
+  RUNSPEC=runtests
+  DOCKER=ariovistus/pyd-test-env:ubuntu1604-ldc190-py35
+- DC=ldc
+  PYTHON=python
+  DUBCFG=python27
+  RUNSPEC=runtests
+  DOCKER=ariovistus/pyd-test-env:ubuntu1604-ldc190-py35
+- DC=ldc
+  PYTHON=python3
+  DUBCFG=python36
+  RUNSPEC=runtests
+  DOCKER=ariovistus/pyd-test-env:fedora28-ldc180-py36
+- DC=ldc
+  PYTHON=python
+  DUBCFG=python27
+  RUNSPEC=runtests
+  DOCKER=ariovistus/pyd-test-env:fedora28-ldc180-py36
+- DC=dmd
+  PYTHON=python3
+  DUBCFG=python34
+  RUNSPEC=runtests
+  DOCKER=ariovistus/pyd-test-env:jessie-dmd2_074-py34
 script: 
-    - python3 runtests.py --compiler=$DC $TEST
-    - dub test
-    - source setup/pyd_set_env_vars.sh python3 && dub test -c env
-
+- docker run -v$(pwd)/:/src -e "COMPILER=$DC" -e "RUNSPEC=$RUNSPEC" -e "PYTHON=$PYTHON" -e "DUBCONFIG=$DUBCFG" -t $DOCKER bash runtests.sh
 jobs:
     include:
         - stage: deploy
@@ -236,14 +42,14 @@ jobs:
           os: linux
           language: python
           if: tag IS present
-        
+
           before_deploy: python versionchecker.py
 
           deploy:
             provider: pypi
             skip_cleanup: true
             user: ariovistus
-            password: 
+            password:
                 secure: "fBaxJv4pJOA2gq6VYlBUXKrGJmKN8TdNU1erFvH5ohvcSIpF4a95ElPpu7dBruMuorGYDXvHlfGhEFpaxxkpBWTknJwUp15HUvx1qMJnyfi9qxcID3ieRQ2lbrktiIkNwfjBKPP+nu4/uLg4P7ZgDdY1rGTGCBPOgc9FqVB1ny4="
             on:
                 tags: true

--- a/envs/fedora28-ldc180-py36/Dockerfile
+++ b/envs/fedora28-ldc180-py36/Dockerfile
@@ -1,0 +1,23 @@
+from fedora:28
+
+ENV \
+    COMPILER=dmd \
+    COMPILER_VERSION=2.082.0
+
+run dnf install -y python-devel python-nose python-numpy
+run dnf install -y python3-devel python3-nose python3-numpy
+run dnf install -y ldc gcc xz
+RUN curl -fsS -o /tmp/install.sh https://dlang.org/install.sh \
+    && bash /tmp/install.sh -p /dlang install "${COMPILER}-${COMPILER_VERSION}" \
+    && rm /tmp/install.sh \
+    && rm -rf /dlang/${COMPILER}-*/linux/bin32 \
+    && rm -rf /dlang/${COMPILER}-*/linux/lib32 \
+    && rm -rf /dlang/${COMPILER}-*/html \
+    && rm -rf /dlang/dub-1.0.0/dub.tar.gz
+
+ENV \
+    PATH=/dlang/dub:/dlang/${COMPILER}-${COMPILER_VERSION}/linux/bin64:${PATH} \
+    LD_LIBRARY_PATH=/dlang/${COMPILER}-${COMPILER_VERSION}/linux/lib64 \
+    LIBRARY_PATH=/dlang/${COMPILER}-${COMPILER_VERSION}/linux/lib64 \
+    PS1="(${COMPILER}-${COMPILER_VERSION}) \\u@\\h:\\w\$"
+workdir /src

--- a/envs/jessie-dmd2_074-py34/Dockerfile
+++ b/envs/jessie-dmd2_074-py34/Dockerfile
@@ -1,0 +1,31 @@
+from python:3.4-jessie
+
+ENV \
+ 	COMPILER=dmd \
+	COMPILER_VERSION=2.074.0
+
+RUN apt-get update && apt-get install -y curl libcurl3 build-essential \
+ && curl -fsS -o /tmp/install.sh https://dlang.org/install.sh \
+ && bash /tmp/install.sh -p /dlang install "${COMPILER}-${COMPILER_VERSION}" \
+ && rm /tmp/install.sh \
+ && apt-get autoremove -y curl build-essential \
+ && apt-get install -y gcc \
+ && rm -rf /var/cache/apt \
+ && rm -rf /dlang/${COMPILER}-*/linux/bin32 \
+ && rm -rf /dlang/${COMPILER}-*/linux/lib32 \
+ && rm -rf /dlang/${COMPILER}-*/html \
+ && rm -rf /dlang/dub-1.0.0/dub.tar.gz
+
+ENV \
+  PATH=/dlang/dub:/dlang/${COMPILER}-${COMPILER_VERSION}/linux/bin64:${PATH} \
+  LD_LIBRARY_PATH=/dlang/${COMPILER}-${COMPILER_VERSION}/linux/lib64 \
+  LIBRARY_PATH=/dlang/${COMPILER}-${COMPILER_VERSION}/linux/lib64 \
+  PS1="(${COMPILER}-${COMPILER_VERSION}) \\u@\\h:\\w\$"
+
+RUN cd /tmp \
+ && echo 'void main() {import std.stdio; stdout.writeln("it works"); }' > test.d \
+ && dmd test.d \
+ && ./test && rm test*
+
+RUN pip3 install nose numpy
+WORKDIR /src

--- a/envs/run.sh
+++ b/envs/run.sh
@@ -1,1 +1,2 @@
-docker run -v$(pwd)/../:/pyd -it hazoo bash
+docker run -v$(pwd)/../:/src -e "COMPILER=dmd" -e "RUNSPEC=runtests" -e "PYTHON=python3.4" -e "DUBCONFIG=python34" -t jess bash runtests.sh
+#docker run -v$(pwd)/../:/src -e "COMPILER=dmd" -e "RUNSPEC=runtests" -e "PYTHON=python3.4" -e "DUBCONFIG=python34" -it jess bash 

--- a/envs/run.sh
+++ b/envs/run.sh
@@ -1,2 +1,4 @@
-docker run -v$(pwd)/../:/src -e "COMPILER=dmd" -e "RUNSPEC=runtests" -e "PYTHON=python3.4" -e "DUBCONFIG=python34" -t jess bash runtests.sh
+#docker run -v$(pwd)/../:/src -e "COMPILER=dmd" -e "RUNSPEC=runtests" -e "PYTHON=python3.4" -e "DUBCONFIG=python34" -t jess bash runtests.sh
 #docker run -v$(pwd)/../:/src -e "COMPILER=dmd" -e "RUNSPEC=runtests" -e "PYTHON=python3.4" -e "DUBCONFIG=python34" -it jess bash 
+docker run -v$(pwd)/../:/src -e "COMPILER=gdc" -e "RUNSPEC=runtests:PydUnittests.test_struct_wrap" -e "PYTHON=python3.7" -e "DUBCONFIG=python37" -it ariovistus/pyd-test-env:stretch-gdc63-py37 bash  runtests.sh
+#docker run -v$(pwd)/../:/src -e "COMPILER=gdc" -e "RUNSPEC=runtests" -e "PYTHON=python3.7" -e "DUBCONFIG=python37" -it lass bash 

--- a/envs/stretch-gdc63-py37/Dockerfile
+++ b/envs/stretch-gdc63-py37/Dockerfile
@@ -1,0 +1,24 @@
+from python:3.7-stretch
+
+ENV \
+ 	COMPILER=gdc \
+	COMPILER_VERSION=6.3.0
+
+RUN apt-get update && apt-get install -y curl libcurl3 build-essential 
+
+RUN curl -o dub.tar.gz https://code.dlang.org/files/dub-1.9.0-linux-x86_64.tar.gz && \
+    tar -xf dub.tar.gz && \
+    mv dub /bin && \
+    rm -rf dub.tar.gz
+
+RUN curl https://gdcproject.org/downloads/binaries/6.3.0/x86_64-linux-gnu/gdc-6.3.0+2.068.2.tar.xz -o gdc-6.3.0+2.068.2.tar.xz && \
+    tar -xf gdc-6.3.0+2.068.2.tar.xz && \
+    mv /x86_64-unknown-linux-gnu/include/c++/6.3.0/ /x86_64-unknown-linux-gnu/include/c++/6 && \
+    cp -ax /x86_64-unknown-linux-gnu/lib64/* /x86_64-unknown-linux-gnu/lib && \
+    cp x86_64-unknown-linux-gnu/* /usr -R  && \
+    rm gdc-6.3.0+2.068.2.tar.xz && \
+    rm x86_64-unknown-linux-gnu/ -rf
+
+RUN pip3 install nose numpy
+
+WORKDIR /src

--- a/envs/ubuntu1604-ldc190-py35/Dockerfile
+++ b/envs/ubuntu1604-ldc190-py35/Dockerfile
@@ -1,0 +1,5 @@
+from dlanguage/ldc:1.9.0
+
+RUN apt-get update && apt-get install -y python python-dev python3 python3-dev python-pip python3-pip python-nose python-numpy python3-nose python3-numpy
+
+WORKDIR /src

--- a/examples/misc/d_and_c/setup.py
+++ b/examples/misc/d_and_c/setup.py
@@ -2,7 +2,7 @@ from distutils.core import Extension as cExtension
 from pyd.support import setup, Extension
 
 module1 = Extension("x", sources = ['xclass.c'])
-module2 = Extension("y", sources = ['hello.d'], build_deimos=True)
+module2 = Extension("y", sources = ['hello.d'], build_deimos=True, d_lump=True)
 
 setup(
     name = "x",

--- a/examples/misc/gdc_sharedlibs/makefile
+++ b/examples/misc/gdc_sharedlibs/makefile
@@ -18,19 +18,22 @@ clean:
 	rm -f *.so
 	rm -f *.x
 
-LIBS= -lrt -lpthread -ldl -lm -lpython2.7 /usr/lib64/libgdruntime.a /usr/lib64/libgphobos2.a
+LIBS= -lrt -lpthread -ldl -lm -lpython3.7m
+
+so_ctor.o: so_ctor.c
+	gcc -c -fPIC so_ctor.c -o so_ctor.o
 
 %.o: %.d
 	echo "building $@"
-	$(GDC) -fPIC -c $^ -o $@
+	$(GDC) -fPIC -c $^ -o $@ --shared
 
-lib%.so: %.o boilerplate.o
+lib%.so: %.o boilerplate.o so_ctor.o
 	echo "building $@"
-	gcc -nostartfiles -shared $(LIBS) $^ -o $@
+	$(GDC) -shared $(LIBS) $^ -o $@ -lgphobos -lgdruntime
 
 test1.x: test1.c libtest1.so
 	echo "building $@"
-	gcc $< -l:libtest1.so -o $@
+	gcc $< -L. -ltest1 -o $@ --verbose
 
 test2.x: test2.c libtest2a.so libtest2b.so
 	echo "building $@"

--- a/examples/misc/gdc_sharedlibs/so_ctor.c
+++ b/examples/misc/gdc_sharedlibs/so_ctor.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+void my_init();
+void my_fini();
+
+__attribute__((__constructor__)) void actual_init() {
+    printf("initing\n");
+    my_init();
+}
+__attribute__((__destructor__)) void actual_fini() {
+    printf("dniting\n");
+    my_fini();
+}
+

--- a/examples/misc/gdc_sharedlibs/test1.d
+++ b/examples/misc/gdc_sharedlibs/test1.d
@@ -11,6 +11,7 @@ unittest {
 }
 
 extern(C) int foo(int i) {
+	auto a = new char[1];
     return i+1;
 }
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+$PYTHON setup.py install
+$PYTHON runtests.py $RUNSPEC --clean
+$PYTHON runtests.py $RUNSPEC --compiler $COMPILER
+
+dub test --config=$DUBCONFIG
+source setup/pyd_set_env_vars.sh $PYTHON && dub test -c env


### PR DESCRIPTION
reimplement travis ci using docker
tests now cover python 2.7, 3.4, 3.5, 3.6, 3.7, and assorted versions of dmd, ldc and gdc
also, get gdc to build extensions again