### PR TITLE
fix: SimpleFormatType static if 'statement is not reachable'

### DIFF
--- a/infrastructure/pyd/make_object.d
+++ b/infrastructure/pyd/make_object.d
@@ -1289,8 +1289,9 @@ template SimpleFormatType(T) {
                 return to_python(isSigned!T ? "i" : "I");
             }else static if(isIntegral!T && T.sizeof == 8) {
                 return to_python(isSigned!T ? "q" : "Q");
+            }else {
+                return null;
             }
-            return null;
         }else{
             assert(false);
         }

--- a/tests/pyd_unittests/make_object/make_object.d
+++ b/tests/pyd_unittests/make_object/make_object.d
@@ -162,6 +162,13 @@ unittest {
 }
 }
 
+// tests that SimpleFormatType template compiles
+unittest
+{
+    auto type = SimpleFormatType!int.pyType();
+    assert(type != null);
+}
+
 // tests on MatrixInfo utility template
 unittest {
     alias MatrixInfo!(double[][]) M1;


### PR DESCRIPTION
Fixes failed compilation occurring on DMD (v2.087.1) and LDC (1.16.0): `make_object.d(1293,13): Warning: statement is not reachable`