### PR TITLE
Updating the dependency on pyd. Fixes the build.

### DIFF
--- a/examples/dub/simple_embedded/dub.json
+++ b/examples/dub/simple_embedded/dub.json
@@ -6,7 +6,7 @@
         "targetType": "executable",
         "dflags-posix-dmd": ["-defaultlib=libphobos2.so"],
 	"dependencies": {
-            "pyd": "0.9.3",
+            "pyd": "~>0.13.0",
 	},
         "subConfigurations": {
             "pyd": "python27",


### PR DESCRIPTION
The dependency for pyd at /pyd/examples/dub/simple_embedded/dub.json needs to be updated.
Otherwise, one gets the error

The sub configuration directive "pyd" -> "python27" references a configuration that does not exists.
Could not resolve configuration for package simple_embedded

For the example, shared_embedded, this chage didn't work as the configuration python27-shared does not exists in the latest version of pyd. Please fix that also!
