### PR TITLE
[FIX] Compilinng with python38 on posix system.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -274,7 +274,7 @@
 				"python38"
 			],
 			"libs-posix": [
-				"python3.8m"
+				"python3.8"
 			],
 			"lflags-windows-x86_64-ldc": [
 				"\"\"/LIBPATH:$USERPROFILE\\AppData\\Local\\Programs\\Python\\Python38\\libs\"\"",


### PR DESCRIPTION
Starting from python38 there is not python38m library.
See https://docs.python.org/3/whatsnew/3.8.html#build-and-c-api-changes

Before this Pull Request attempt to compile PyD on Ubuntu 20.04 causes following error:
```traceback
Performing "debug" build using /usr/bin/dmd for x86_64.
darg 0.1.0: target for configuration "library" is up to date.
tinyendian 0.2.0: target for configuration "library" is up to date.
dyaml 0.8.0: target for configuration "library" is up to date.
pyd ~master: target for configuration "python38" is up to date.
semver 0.3.2: target for configuration "library" is up to date.
termcolor-d 0.0.1: target for configuration "library" is up to date.
odoo-packager ~dev: building configuration "executable_py38"...
Linking...
/usr/bin/ld: cannot find -lpython3.8m
collect2: error: ld returned 1 exit status
```
After this commit it compiles and works find