### PR TITLE
add complex class test

### DIFF
--- a/examples/dub/simple_embedded/source/c.py
+++ b/examples/dub/simple_embedded/source/c.py
@@ -1,0 +1,6 @@
+
+c = complex(2,-1)
+h = c.__hash__();
+
+print(c)
+print(h)

--- a/examples/dub/simple_embedded/source/hello.d
+++ b/examples/dub/simple_embedded/source/hello.d
@@ -9,8 +9,9 @@ shared static this() {
 
 void main() {
     writeln(py_eval!string("'1 + %s' % 2"));
+
+    auto c = py_eval("complex(2,-1)");
+    auto h = c.__hash__();
+    writeln(c);
+    writeln(h);
 }
-
-
-
-


### PR DESCRIPTION
This is a bug report actually:

```
$ cat c.py

c = complex(2,-1)
h = c.__hash__();

print(c)
print(h)

# python output
$ python c.py 
(2-1j)
-2000004   # here!
```

however, pyd output:
```
$ dub build
$ ./simple_embedded 
1 + 2
(2-1j)
<method-wrapper '__hash__' of complex object at 0x7fa8c49897d0>  # here!
```

