### PR TITLE
Use a function to avoid polluting/overwriting envvars

### DIFF
--- a/setup/pyd_set_env_vars.sh
+++ b/setup/pyd_set_env_vars.sh
@@ -1,18 +1,22 @@
-if [ -v BASH_SOURCE ]; then
-	THIS=${BASH_SOURCE[0]}
-elif [ -v ZSH_VERSION ]; then
-	THIS=${(%):-%x}
-else
-	THIS=$0
-fi
+main() {
+	if [ -v BASH_SOURCE ]; then
+		local -r THIS=${BASH_SOURCE[0]}
+	elif [ -v ZSH_VERSION ]; then
+		local -r THIS=${(%):-%x}
+	else
+		local -r THIS=$0
+	fi
 
-THISDIR=$( cd $(dirname $THIS) > /dev/null ; pwd -P )
+	local -r THISDIR=$( cd $(dirname $THIS) > /dev/null ; pwd -P )
 
-if [ -z $1 ]; then
-	echo 'python interpreter not specified, using "python"'
-	PYD_PYTHON=python
-else
-	PYD_PYTHON=$1
-fi
+	if [ -z $1 ]; then
+		echo 'python interpreter not specified, using "python"'
+		local -r PYD_PYTHON=python
+	else
+		local -r PYD_PYTHON=$1
+	fi
 
-eval $($PYD_PYTHON $THISDIR/pyd_get_env_set_text.py)
+	eval $($PYD_PYTHON $THISDIR/pyd_get_env_set_text.py)
+}
+
+main


### PR DESCRIPTION
Turns out some other script of ours that `source`s this also uses the same idiom for figuring out the location of the script. Same names, too! Making the variables readonly revealed this problem.