### PR TITLE
Fixup following bug introduced in #148

### DIFF
--- a/setup/pyd_set_env_vars.sh
+++ b/setup/pyd_set_env_vars.sh
@@ -1,22 +1,25 @@
-main() {
+#!/===you-must-source-this-script===/
+
+main_b97532fa() {
 	if [ -v BASH_SOURCE ]; then
-		local -r THIS=${BASH_SOURCE[0]}
+		local THIS=${BASH_SOURCE[0]}
 	elif [ -v ZSH_VERSION ]; then
-		local -r THIS=${(%):-%x}
+		local THIS=${(%):-%x}
 	else
-		local -r THIS=$0
+		local THIS=$0
 	fi
 
-	local -r THISDIR=$( cd $(dirname $THIS) > /dev/null ; pwd -P )
+	local THISDIR
+	THISDIR=$( cd "$(dirname "$THIS")" > /dev/null ; pwd -P ) || return 1
 
-	if [ -z $1 ]; then
+	if [ $# -eq 0 ]; then
 		echo 'python interpreter not specified, using "python"'
-		local -r PYD_PYTHON=python
+		local PYD_PYTHON=python
 	else
-		local -r PYD_PYTHON=$1
+		local PYD_PYTHON=$1
 	fi
 
-	eval $($PYD_PYTHON $THISDIR/pyd_get_env_set_text.py)
+	eval "$($PYD_PYTHON "$THISDIR"/pyd_get_env_set_text.py)"
 }
 
-main
+main_b97532fa "$@"


### PR DESCRIPTION
Need to egg my face, I introduced a bug in https://github.com/ariovistus/pyd/pull/148/ - forgot to pass arguments down from the script to the main function. I made untested edits in that PR ("what's the worst that could happen?"); this time I tested this carefully.

Took the opportunity to make a few improvements that make the script more robust:

- the shebang line avoids inadvertently running the script in a separate shell, otherwise it would appear to run successfully but have no effect
- `main` has a random suffix so as to avoid clashing with some other `main` in the current environment
- replaced the test `-z $1` with `$# -eq 0` because if the calling environment has `set -u`, it would fail on account of unset variable
- quoted strings as https://www.shellcheck.net indicated, on the off chance somebody has spaces in dir names

Apologies for the mess!