### PR TITLE
Revert "Fix another deprecation wrt. escaping `this`"

### DIFF
--- a/infrastructure/pyd/make_object.d
+++ b/infrastructure/pyd/make_object.d
@@ -1186,7 +1186,7 @@ struct RangeWrapper {
     bool delegate() empty;
     TypeInfo tid;
 
-    RangeWrapper* iter() return {
+    RangeWrapper* iter() {
         return &this;
     }
     PyObject* next() {


### PR DESCRIPTION
This reverts commit d18d388b1bbf4ba9e50fec6e49087c13a40a2d6c.

This fixes this compilation error:
```
pyd/infrastructure/pyd/func_wrap.d(802,22): Error: cannot implicitly convert expression `fn` of type `RangeWrapper* function() return` to `RangeWrapper* function()`
pyd/infrastructure/pyd/func_wrap.d-mixin-405(407,33): Error: template instance `pyd.func_wrap.dg_wrapper!(RangeWrapper*, RangeWrapper* function() return)` error instantiating
pyd/infrastructure/pyd/func_wrap.d(364,19):        instantiated from here: `memberfunc_to_func!(RangeWrapper*, iter)`
pyd/infrastructure/pyd/class_wrap.d(311,48):        instantiated from here: `method_wrap!(RangeWrapper*, iter, "RangeWrapper.__iter__")`
pyd/infrastructure/pyd/class_wrap.d(1580,22):        instantiated from here: `call!("RangeWrapper", RangeWrapper*)`
pyd/infrastructure/pyd/class_wrap.d(1551,5):        instantiated from here: `_wrap_class!(RangeWrapper, "RangeWrapper", "", "pyd", Def!(iter, PyName!"__iter__"), Def!(next))`
pyd/infrastructure/pyd/make_object.d(75,13):        instantiated from here: `wrap_struct!(RangeWrapper, ModuleName!"pyd", Def!(iter, PyName!"__iter__"), Def!(next))`
pyd/infrastructure/pyd/func_wrap.d(247,29): Error: template instance `pyd.func_wrap.applyPyTupleToAlias!(func, "RangeWrapper.__iter__")` error instantiating
pyd/infrastructure/pyd/func_wrap.d(365,20):        instantiated from here: `pyApplyToAlias!(func, "RangeWrapper.__iter__")`
pyd/infrastructure/pyd/class_wrap.d(311,48):        instantiated from here: `method_wrap!(RangeWrapper*, iter, "RangeWrapper.__iter__")`
pyd/infrastructure/pyd/class_wrap.d(1580,22):        instantiated from here: `call!("RangeWrapper", RangeWrapper*)`
pyd/infrastructure/pyd/class_wrap.d(1551,5):        instantiated from here: `_wrap_class!(RangeWrapper, "RangeWrapper", "", "pyd", Def!(iter, PyName!"__iter__"), Def!(next))`
pyd/infrastructure/pyd/make_object.d(75,13):        instantiated from here: `wrap_struct!(RangeWrapper, ModuleName!"pyd", Def!(iter, PyName!"__iter__"), Def!(next))`
pyd/infrastructure/pyd/class_wrap.d(1356,29): Error: template instance `pyd.op_wrap.opiter_wrap!(RangeWrapper*, iter)` error instantiating
pyd/infrastructure/pyd/class_wrap.d(1634,26):        instantiated from here: `call!(RangeWrapper*)`
pyd/infrastructure/pyd/class_wrap.d(1551,5):        instantiated from here: `_wrap_class!(RangeWrapper, "RangeWrapper", "", "pyd", Def!(iter, PyName!"__iter__"), Def!(next))`
pyd/infrastructure/pyd/make_object.d(75,13):        instantiated from here: `wrap_struct!(RangeWrapper, ModuleName!"pyd", Def!(iter, PyName!"__iter__"), Def!(next))`
```