### PR TITLE
Make code compatible with ldc 1.40.0.

### DIFF
--- a/infrastructure/pyd/util/multi_index.d
+++ b/infrastructure/pyd/util/multi_index.d
@@ -120,6 +120,12 @@ template IsAllocator(T) {
         is(typeof(T.deallocate!int((int*).init)) == void);
 }
 
+auto noThrowFormat(Args...)(string pattern, Args args) nothrow {
+    try return format(pattern, args);
+    catch (Exception e) { assert(0,e.msg); }
+}
+
+
 /// A doubly linked list index.
 template Sequenced() {
     // no memory allocations occur within this index.
@@ -190,9 +196,9 @@ bidirectional range
             void insertNext(typeof(this)* node) nothrow
             in (node !is null)
             in (node.index!N.prev is null,
-                    format("node.prev = %x", node.index!N.prev))
+                    noThrowFormat("node.prev = %x", node.index!N.prev))
             in (node.index!N.next is null,
-                    format("node.next = %x", node.index!N.next))
+                    noThrowFormat("node.next = %x", node.index!N.next))
             {
                 typeof(this)* n = next;
                 next = node;
@@ -207,9 +213,9 @@ bidirectional range
             void insertPrev(typeof(this)* node) nothrow
             in (node !is null)
             in (node.index!N.prev is null,
-                    format("node.prev = %x", node.index!N.prev))
+                    noThrowFormat("node.prev = %x", node.index!N.prev))
             in (node.index!N.next is null,
-                    format("node.next = %x", node.index!N.next))
+                    noThrowFormat("node.next = %x", node.index!N.next))
             {
                 typeof(this)* p = prev;
                 if(p !is null) p.index!N.next = node;


### PR DESCRIPTION
The current code gives the following error when compiling with ldc 1.40.0 or later:

```./../../../.dub/packages/pyd/0.14.5/pyd/infrastructure/pyd/util/multi_index.d(190,18): Error: pyd.util.multi_index.MNode!(MultiIndexContainer!(DStruct_Py_Mapping, IndexedBy!(__T6HashedVbi1VAyaa3_612e64VQna35_636173742873697a655f7429202a6361737428636f6e737420766f69642a2a29202661VQDma4_613d3d62Z, "d", __T6HashedVbi0VAyaa4_612e7079VQpa35_636173742873697a655f7429202a6361737428636f6e737420766f69642a2a29202661VQDoa4_613d3d62Z, "python"), MallocAllocator, MutableView), IndexedBy!(__T6HashedVbi1VAyaa3_612e64VQna35_636173742873697a655f7429202a6361737428636f6e737420766f69642a2a29202661VQDma4_613d3d62Z, "d", __T6HashedVbi0VAyaa4_612e7079VQpa35_636173742873697a655f7429202a6361737428636f6e737420766f69642a2a29202661VQDoa4_613d3d62Z, "python"), MallocAllocator, Inner!(IndexedBy!(__T6HashedVbi1VAyaa3_612e64VQna35_636173742873697a655f7429202a6361737428636f6e737420766f69642a2a29202661VQDma4_613d3d62Z, "d", __T6HashedVbi0VAyaa4_612e7079VQpa35_636173742873697a655f7429202a6361737428636f6e737420766f69642a2a29202661VQDoa4_613d3d62Z, "python")), DStruct_Py_Mapping, DStruct_Py_Mapping).MNode.NodeMixin!0LU.insertNext: in contract may throw but function is nothrow.
```

My change just replaces the call so format with a noThrowFormat which I added, which will assert(0) instead of throw.